### PR TITLE
feat(github-pr): Add title prompt dialog before download

### DIFF
--- a/feature-comparison.md
+++ b/feature-comparison.md
@@ -2,7 +2,7 @@
 
 此表格比較本儲存庫中不同「轉為 Markdown」使用者腳本的功能。
 
-| 功能 | `gemini-to-markdown` (0.7) | `jules-to-markdown` (0.8) | `claude-to-markdown` (0.7) | `claude-code-web-to-markdown` (0.1) | `ptt-to-markdown` (0.3) | `threads-to-markdown` (0.5) | `github-pr-to-markdown` (0.2) |
+| 功能 | `gemini-to-markdown` (0.7) | `jules-to-markdown` (0.8) | `claude-to-markdown` (0.7) | `claude-code-web-to-markdown` (0.1) | `ptt-to-markdown` (0.3) | `threads-to-markdown` (0.5) | `github-pr-to-markdown` (0.3) |
 | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | **基本轉換** | | | | | | | |
 | 文字與基本格式 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -33,4 +33,5 @@
 | **輸出格式** | | | | | | | |
 | 檔名（非 ASCII） | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Frontmatter 標題（非 ASCII） | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| 下載前可設定標題 | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
 | 對話順序編號 | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |

--- a/github-pr-to-markdown.user.js
+++ b/github-pr-to-markdown.user.js
@@ -1,12 +1,13 @@
 // ==UserScript==
 // @name         GitHub PR to Markdown
 // @namespace    https://github.com/Aiuanyu/GeminiChat2MD
-// @version      0.2
+// @version      0.3
 // @description  Downloads a GitHub pull request conversation as a Markdown file.
 // @author       Aiuanyu & Jules
 // @match        https://github.com/*/*/pull/*
 // @grant        none
 // @license      MIT
+// @history      0.3 2025-12-21 - Added a dialog to set the title before downloading.
 // @history      0.2 Initial release with PR conversation extraction
 // @history      0.1 Development version
 // ==/UserScript==
@@ -14,7 +15,7 @@
 (function() {
     'use strict';
 
-    const SCRIPT_VERSION = '0.2';
+    const SCRIPT_VERSION = '0.3';
 
     function addStyles() {
         const css = `
@@ -58,7 +59,26 @@
         const titleElement = document.querySelector('.gh-header-title .js-issue-title');
         const prNumber = document.querySelector('.gh-header-title .f1-light')?.textContent?.trim() || '';
         const title = titleElement ? titleElement.textContent.trim() : 'GitHub PR';
-        return `${prNumber.replace('#', '')} ${title}`.replace(/[\/\\?%*:|"<>]/g, '-');
+        return `${prNumber.replace('#', '')} ${title}`;
+    }
+
+    function sanitizeFilename(name) {
+        return name.replace(/[\/\\?%*:|"<>]/g, '-');
+    }
+
+    function escapeYamlString(str) {
+        return str.replace(/"/g, '\\"');
+    }
+
+    function showTitlePrompt(defaultTitle, callback) {
+        let title = prompt("Enter the title for the Markdown file:", defaultTitle);
+        if (title === null) {
+            return; // User cancelled
+        }
+        if (title.trim() === '') {
+            title = defaultTitle;
+        }
+        callback(title);
     }
 
     function nodeToMarkdown(node) {
@@ -162,7 +182,7 @@
         return `> *System Event: ${text}*\n\n`;
     }
 
-    function extractContent() {
+    function extractContent(title) {
         const titleEl = document.querySelector('.gh-header-title .js-issue-title');
         const prNumber = document.querySelector('.gh-header-title .f1-light')?.textContent?.trim() || '';
         const author = document.querySelector('.gh-header-meta .author')?.textContent.trim() || 'unknown';
@@ -173,7 +193,7 @@
 
         let markdown = `---
 parser: "GitHub PR to Markdown v${SCRIPT_VERSION}"
-title: "${titleEl.textContent.trim()}"
+title: "${escapeYamlString(title)}"
 number: ${prNumber.replace('#', '')}
 url: "${window.location.href}"
 author: ${author}
@@ -183,7 +203,7 @@ base: "${baseRef}"
 labels: [${labels.map(l => `"${l.replace(/"/g, '\\"')}"`).join(', ')}]
 ---
 
-# PR: ${titleEl.textContent.trim()} (${prNumber})
+# PR: ${title} (${prNumber})
 
 `;
 
@@ -220,16 +240,19 @@ labels: [${labels.map(l => `"${l.replace(/"/g, '\\"')}"`).join(', ')}]
     }
 
     function downloadMarkdown() {
-        const markdownContent = extractContent();
-        const blob = new Blob([markdownContent], { type: 'text/markdown;charset=utf-8' });
-        const url = URL.createObjectURL(blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `${getSanitizedTitle()}.md`;
-        document.body.appendChild(a);
-        a.click();
-        document.body.removeChild(a);
-        URL.revokeObjectURL(url);
+        const defaultTitle = getSanitizedTitle();
+        showTitlePrompt(defaultTitle, (title) => {
+            const markdownContent = extractContent(title);
+            const blob = new Blob([markdownContent], { type: 'text/markdown;charset=utf-8' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `${sanitizeFilename(title)}.md`;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        });
     }
 
     // Use a MutationObserver to wait for the page to be ready


### PR DESCRIPTION
Apply PR #45 feature to github-pr-to-markdown.user.js:
- Add dialog to set title before downloading
- Add sanitizeFilename(), escapeYamlString(), showTitlePrompt() functions
- Modify extractContent() to accept title parameter
- Modify downloadMarkdown() to show title prompt
- Update version to 0.3
- Add @history entry for version 0.3
- Update feature-comparison.md with new feature and version

This brings github-pr-to-markdown.user.js feature parity with PR #45.